### PR TITLE
Fix up the wiki links

### DIFF
--- a/PQSMods/PQSMods.md
+++ b/PQSMods/PQSMods.md
@@ -13,6 +13,6 @@ Each PQSMod subnode contains `name`, `order`, and `enabled` keys, as described b
 |order|Integer|The order that the PQSMod should be processed in. PQSMods are processed in increasing `order` value, so a mod with `order` 20 would be applied before a mod with order `100`.|
 
 **PQSMods**
-+ [LandControl]({{site.baseurl}}{% link /PQSMods/LandControl.md %})
-+ [VertexColorMap]({{site.baseurl}}{% link /PQSMods/VertexColorMap.md %})
-+ [VertexHeightMap]({{site.baseurl}}{% link /PQSMods/VertexHeightMap.md %})
++ [LandControl]({{ site.baseurl }}{% link PQSMods/LandControl.md %})
++ [VertexColorMap]({{ site.baseurl }}{% link PQSMods/VertexColorMap.md %})
++ [VertexHeightMap]({{ site.baseurl }}{% link PQSMods/VertexHeightMap.md %})

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ ForANode
 |(Example) order|Integer|The order the PQSMod should be applied in.| 
 
 ### Links
-Links are to be in the form `[text]({{site.baseurl}}{% link <path in repo>%})`
+Links are to be in the form `[text]({{ site.baseurl }}{% link <path in repo> %})`

--- a/index.md
+++ b/index.md
@@ -14,55 +14,55 @@ subtitle: A mod to modify the planetary system used by KSP
 ---
 
 # Prerequisites
-* [What are ConfigNodes?]({{ "main/ConfigNodes.html" | relative_url  }})
+* [What are ConfigNodes?]({{ site.baseurl }}{% link main/ConfigNodes.md %})
 * [A Beginner's Guide to Kopernicus: The Basics](https://forum.kerbalspaceprogram.com/index.php?/topic/129540-a-beginners-guide-to-kopernicus-the-basics/)
-* [Data Types]({{ "main/datatypes.html" | relative_url  }})
+* [Data Types]({{ site.baseurl }}{% link main/datatypes.md %})
 
 ## Syntax for planets
-* [Body node]({{ "main/Body.html" | relative_url  }})
-  + [Template subnode]({{ "main/Template.html" | relative_url  }})
-  + [Properties subnode]({{ "main/Properties.html" | relative_url  }})
-    - [ScienceValues subnode]({{ "main/Properties/ScienceValues.html" | relative_url  }})
-    - [Biomes subnode]({{ "main/Properties/Biome.html" | relative_url  }})
-  + [Orbit subnode]({{ "main/Orbit.html" | relative_url  }})
-  + [ScaledVersion subnode]({{ "main/ScaledVersion.html" | relative_url  }})
+* [Body node]({{ site.baseurl }}{% link main/Body.md %})
+  + [Template subnode]({{{ site.baseurl }}{% link main/Template.md %})
+  + [Properties subnode]({{ site.baseurl }}{% link main/Properties.md %})
+    - [ScienceValues subnode]({{ site.baseurl }}{% link main/Properties/ScienceValues.md %})
+    - [Biomes subnode]({{ site.baseurl }}{% link main/Properties/Biome.md %})
+  + [Orbit subnode]({{ site.baseurl }}{% link main/Orbit.md %})
+  + [ScaledVersion subnode]({{ site.baseurl }}{% link main/ScaledVersion.md %})
     - Material subnode
-  + [Rings subnode]({{ "main/Rings.html" | relative_url  }})
+  + [Rings subnode]({{ site.baseurl }}{% link main/Rings.md %})
   + Atmosphere subnode
     - AtmosphereFromGround subnode
   + PQS subnode
-    - [PQSMod subnodes]({{ "PQSMods/PQSMods.html" | relative_url  }})
+    - [PQSMod subnodes]({{ site.baseurl }}{% link PQSMods/PQSMods.md %})
   + Ocean subnode
-  + [HazardousBody subnode]({{ "main/HazardousBody.html" | relative_url  }})
-  + [Particles subnode]({{ "main/Particle.html" | relative_url  }})
-  + [Debug subnode]({{ "main/Debug.html" | relative_url  }})
+  + [HazardousBody subnode]({{ site.baseurl }}{% link main/HazardousBody.md %})
+  + [Particles subnode]({{ site.baseurl }}{% link main/Particle.md %})
+  + [Debug subnode]({{ site.baseurl }}{% link main/Debug.md %})
 
 ## Syntax for stars
-* [Body node]({{ "main/Body.html" | relative_url  }})
-  + [Template subnode]({{ "main/Template.html" | relative_url  }})
-  + [Properties subnode]({{ "main/Properties.html" | relative_url  }})
-    - [ScienceValues subnode]({{ "main/Properties/ScienceValues.html" | relative_url  }})
-  + [Orbit subnode]({{ "main/Orbit.html" | relative_url  }})
-  + [ScaledVersion subnode]({{ "main/ScaledVersion.html" | relative_url  }})
+* [Body node]({{ site.baseurl }}{% link main/Body.md %})
+  + [Template subnode]({{{ site.baseurl }}{% link main/Template.md %})
+  + [Properties subnode]({{ site.baseurl }}{% link main/Properties.md %})
+    - [ScienceValues subnode]({{ site.baseurl }}{% link main/Properties/ScienceValues.md %})
+  + [Orbit subnode]({{ site.baseurl }}{% link main/Orbit.md %})
+  + [ScaledVersion subnode]({{ site.baseurl }}{% link main/ScaledVersion.md %})
     - Material subnode
-    - [Light subnode]({{ "main/ScaledVersion/Light.html" | relative_url  }})
-    - [Coronas subnode]({{ "main/ScaledVersion/Corona.html" | relative_url  }})
-  + [Rings subnode]({{ "main/Rings.html" | relative_url  }})
+    - [Light subnode]({{ site.baseurl }}{% link main/ScaledVersion/Light.md %})
+    - [Coronas subnode]({{ site.baseurl }}{% link main/ScaledVersion/Corona.md %})
+  + [Rings subnode]({{ site.baseurl }}{% link main/Rings.md %})
   + Atmosphere subnode
   + Ocean subnode
   + HazardousBody subnode
   + Particles subnode
-  + [Debug subnode]({{ "main/Debug.html" | relative_url  }})
+  + [Debug subnode]({{ site.baseurl }}{% link main/Debug.md %})
 
 # KopernicusExpansion
 ### WARNING: These pages are not intended for beginners, and a basic level of experience is assumed.
-*   [Comet Tails]({{ "kex/CometTails.html" | relative_url  }})
-*   [Emissive FX]({{ "kex/EmissiveFX.html" | relative_url  }})
-*   [EVA Footprints]({{ "kex/EVAFootprints.html" | relative_url  }})
+*   [Comet Tails]({{ site.baseurl }}{% link kex/CometTails.md %})
+*   [Emissive FX]({{ site.baseurl }}{% link kex/EmissiveFX.md %})
+*   [EVA Footprints]({{ site.baseurl }}{% link kex/EVAFootprints.md %})
 *   Modular Noise
-*   [Procedural Gas Giants]({{ "kex/ProceduralGasGiants.html" | relative_url  }})
-*   [Reentry Effects]({{ "kex/ReentryEffects.html" | relative_url  }})
+*   [Procedural Gas Giants]({{ site.baseurl }}{% link kex/ProceduralGasGiants.md %})
+*   [Reentry Effects]({{ site.baseurl }}{% link kex/ReentryEffects.md %})
 *   Regional PQS Mods
-*   [VertexHeightDeformity]({{ "kex/VertexHeightDeformity.html" | relative_url  }})
-*   [VertexHeightMap16]({{ "kex/VertexHeightMap16.html" | relative_url  }})
-*   [Wormholes]({{ "kex/Wormholes.html" | relative_url  }})
+*   [VertexHeightDeformity]({{ site.baseurl }}{% link kex/VertexHeightDeformity.md %})
+*   [VertexHeightMap16]({{ site.baseurl }}{% link kex/VertexHeightMap16.md %})
+*   [Wormholes]({{ site.baseurl }}{% link kex/Wormholes.md %})

--- a/main/Orbit.md
+++ b/main/Orbit.md
@@ -26,7 +26,7 @@ Orbit
 |Property|Format|Description|
 |--------|------|-----------|
 |referenceBody|String|The `name` of the object the body orbits.|   
-|color|Color|The color of the orbit line. See [the datatypes page]({{ site.baseurl }}{% link /main/datatypes.md %}) for more info on colors.| 
+|color|Color|The color of the orbit line. See [the datatypes page]({{ site.baseurl }}{% link main/datatypes.md %}) for more info on colors.| 
 |inclination|Double|The tilt of the orbit in degrees. 0 = normal, 90 = polar, 180 = retrograde, etc...|
 |eccentricity|Double|The difference between your body's apoapsis and periapsis. It is a value between 0 and 1, where 0 is a perfect circle, and 1 is a straight line. 0.5 would give an oval shape.|
 |period|Double|The custom orbital period in seconds. This can be used to set extreme orbital periods.|
@@ -36,7 +36,7 @@ Orbit
 |[meanAnomalyAtEpoch](https://en.wikipedia.org/wiki/Mean_anomaly)|Double|The position of the body along the orbit, in radians, at the specified epoch.|
 |meanAnomalyAtEpochD|Double|Similar to `meanAnomalyAtEpoch`, but is in degrees instead of radians. Useful for more precise measurement.|
 |epoch|Double|The epoch at which `meanAnomalyAtEpoch` is described.|
-|iconColor|[Color]({{ site.baseurl }}{% link /main/datatypes.md %})|(Also nodeColor) The color of the orbit icon/node.|
+|iconColor|[Color]({{ site.baseurl }}{% link main/datatypes.md %})|(Also nodeColor) The color of the orbit icon/node.|
 |iconTexture|File Path|The path to the custom icon texture.|
 |mode|OrbitDrawMode|Orbit Draw Mode. Possible values are `OFF`, `REDRAW_ONLY`, `REDRAW_AND_FOLLOW`, and `REDRAW_AND_RECALCULATE`. Default is `REDRAW_AND_RECALCULATE`.|
 |icon|OrbitDrawIcons|Orbit Icon Mode. Possible values are `NONE`, `OBJ`, `OBJ_PE_AP`, and `ALL`. Default is `ALL`.|

--- a/main/Properties.md
+++ b/main/Properties.md
@@ -8,8 +8,8 @@ The `Properties { }` node describes the body itself, and is a subnode of `Body {
 
 ### Subnodes
 ***
-* [Biomes/Biome { }]({{ site.baseurl }}{% link Properties/Biome.md %})
-* [ScienceValues { }]({{ site.baseurl }}{% link Properties/ScienceValues.md %})
+* [Biomes/Biome { }]({{ site.baseurl }}{% link main/Properties/Biome.md %})
+* [ScienceValues { }]({{ site.baseurl }}{% link main/Properties/ScienceValues.md %})
 
 ## Example:
 ```
@@ -64,4 +64,4 @@ Properties
 |RnDVisibility|RnDVisibility|(Also RDVisibility) The visibility state of the body in the RnD archives. Possible values are `Visible`, `Noicon`, `Hidden`, or `Skip`.|
 |RnDRotation|Boolean|Whether the body should rotate in the RnD archives.|
 |maxZoom|Single|The max zoom limit for the tracking station and the map view. Sets the number of meters that can fit in the full height of the screen.|
-|biomeMap|File Path|The path to the biome map texture. See the [Biome subnode]({{ site.baseurl }}{% link /main/Properties/Biome.md %}) for more information|
+|biomeMap|File Path|The path to the biome map texture. See the [Biome subnode]({{ site.baseurl }}{% link main/Properties/Biome.md %}) for more information|

--- a/main/ScaledVersion.md
+++ b/main/ScaledVersion.md
@@ -8,10 +8,10 @@ The `ScaledVersion { }` node in a configuration file for Kopernicus describes a 
 
 
 **Subnodes**
-* [Material { }]({{ site.baseurl }}{% link /main/ScaledVersion/Material.md %}) = Updates to textures and atmosphere rims.
-* [OnDemand { }]({{ site.baseurl }}{% link /main/ScaledVersion/OnDemand.md %}) = Used for textures that should be loaded OnDemand.
-* [Light { }]({{ site.baseurl }}{% link /main/ScaledVersion/Light.md %}) = Used for making stars.
-* [Coronas { }]({{ site.baseurl }}{% link /main/ScaledVersion/Corona.md %}) = Used for making stars.
+* [Material { }]({{ site.baseurl }}{% link main/ScaledVersion/Material.md %}) = Updates to textures and atmosphere rims.
+* [OnDemand { }]({{ site.baseurl }}{% link main/ScaledVersion/OnDemand.md %}) = Used for textures that should be loaded OnDemand.
+* [Light { }]({{ site.baseurl }}{% link main/ScaledVersion/Light.md %}) = Used for making stars.
+* [Coronas { }]({{ site.baseurl }}{% link main/ScaledVersion/Corona.md %}) = Used for making stars.
 
 **Example**
 ```

--- a/main/Template.md
+++ b/main/Template.md
@@ -19,11 +19,11 @@ Template
 
 |Property|Format|Description|
 |name|String|The name of your template body. *Only the names of stock-bodies are valid.*|
-|removePQS|Boolean|Whether Kopernicus should remove the surface of the template body. See the [PQS subnode]({{ site.baseurl }}{% link /main/PQS.md %}) for more details.|
-|removeAtmosphere|Boolean|Whether to remove the atmosphere from the template body. See the [Atmosphere subnode]({{ site.baseurl }}{% link /main/Atmosphere.md %}) for more details.|
-|removeBiomes|Boolean|Whether to remove the biomes of the template body. See the [Biome subnode]({{ site.baseurl }}{% link /main/Properties/Biome.md %}) for more details.|
-|removeOcean|Boolean|Whether to remove the ocean of the template body. See the [Ocean subnode]({{ site.baseurl }}{% link /main/Oceans.md %}) for more details.|
-|removePQSMods|String[]|A selection of terrain modifications that Kopernicus should remove. Possible values are listed on the [PQSMods page]({{ site.baseurl }}{% link /PQSMods/PQSMods.md %}).|
+|removePQS|Boolean|Whether Kopernicus should remove the surface of the template body. See the [PQS subnode]({{ site.baseurl }}{% link main/PQS.md %}) for more details.|
+|removeAtmosphere|Boolean|Whether to remove the atmosphere from the template body. See the [Atmosphere subnode]({{ site.baseurl }}{% link main/Atmosphere.md %}) for more details.|
+|removeBiomes|Boolean|Whether to remove the biomes of the template body. See the [Biome subnode]({{ site.baseurl }}{% link main/Properties/Biome.md %}) for more details.|
+|removeOcean|Boolean|Whether to remove the ocean of the template body. See the [Ocean subnode]({{ site.baseurl }}{% link main/Oceans.md %}) for more details.|
+|removePQSMods|String[]|A selection of terrain modifications that Kopernicus should remove. Possible values are listed on the [PQSMods page]({{ site.baseurl }}{% link PQSMods/PQSMods.md %}).|
 |removeAllPQSMods|Boolean|Whether to remove every terrain modification from the template body and make it a perfect sphere.|
 |removeProgressTree|Boolean|Whether to remove contracts and milestones from the template body.|
 |removeCoronas|Boolean|Whether to remove the coronas from the template body (really only applicable for the Sun).|


### PR DESCRIPTION
This fixes all the wiki links that broke during the revert of the revert
of my initial fix.

This also causes jekyll to build the wiki correctly again.